### PR TITLE
Exposing ping hooks in Rfc6455 standard

### DIFF
--- a/vtortola.WebSockets.Rfc6455/WebSocketFactoryRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketFactoryRfc6455.cs
@@ -16,9 +16,14 @@ namespace vtortola.WebSockets.Rfc6455
             :base(listener)
         {
         }
+        public Action<WebSocket> OnPingReceived { get; set; }
+
         public override WebSocket CreateWebSocket(Stream stream, WebSocketListenerOptions options, IPEndPoint localEndpoint, IPEndPoint remoteEndpoint, WebSocketHttpRequest httpRequest, WebSocketHttpResponse httpResponse, List<IWebSocketMessageExtensionContext> negotiatedExtensions)
         {
-            return new WebSocketRfc6455(stream, options, localEndpoint, remoteEndpoint, httpRequest, httpResponse, negotiatedExtensions);
+            var webSocket = new WebSocketRfc6455(stream, options, localEndpoint, remoteEndpoint, httpRequest, httpResponse, negotiatedExtensions);
+            if (OnPingReceived != null)
+                webSocket.OnPingReceived = OnPingReceived;
+            return webSocket;
         }
     }
 }

--- a/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
@@ -18,6 +18,7 @@ namespace vtortola.WebSockets.Rfc6455
         public override IPEndPoint LocalEndpoint { get { return _localEndpoint; } }
         public override Boolean IsConnected { get { return Connection.IsConnected; } }
         public TimeSpan Latency { get { return Connection.Latency; } }
+        public Action<WebSocket> OnPingReceived { set { Connection.OnPingReceived = () => value(this); } }
 
         public WebSocketRfc6455(Stream clientStream, WebSocketListenerOptions options, IPEndPoint local, IPEndPoint remote, WebSocketHttpRequest httpRequest, WebSocketHttpResponse httpResponse, IReadOnlyList<IWebSocketMessageExtensionContext> extensions)
             :base(httpRequest, httpResponse)
@@ -46,6 +47,7 @@ namespace vtortola.WebSockets.Rfc6455
             Connection = new WebSocketConnectionRfc6455(clientStream, options);
             _extensions = extensions;
         }
+        
         public override async Task<WebSocketMessageReadStream> ReadMessageAsync(CancellationToken token)
         {
             using (token.Register(this.Close, false))
@@ -110,6 +112,15 @@ namespace vtortola.WebSockets.Rfc6455
         ~WebSocketRfc6455()
         {
             Dispose(false);
+        }
+    }
+
+    public static class WebSocketRfc6455Extensions
+    {
+        public static void Ping(this WebSocket socket)
+        {
+            if (socket is WebSocketRfc6455)
+                ((WebSocketRfc6455)socket).Connection.Ping(DateTime.Now);
         }
     }
 }


### PR DESCRIPTION
We needed more control over both server-side ping to clients, and client-side ping to the server.  We thought you might be interested in pulling this change since it enables projects using the Rfc6455 standard to wire an OnPingReceived action, as well as exposing a means for sending a server-side ping to clients on demand.  Please let me know what you think.  By the way, outstanding work on this websocket server implementation, which is far more performant than .Net's own implementation.