### PR TITLE
added dualstack socket mode, possibility to listen on both ip stacks

### DIFF
--- a/vtortola.WebSockets/WebSocketListener.cs
+++ b/vtortola.WebSockets/WebSocketListener.cs
@@ -26,7 +26,10 @@ namespace vtortola.WebSockets
             _options = options.Clone();
             _cancel = new CancellationTokenSource();
 
-            _listener = new TcpListener(endpoint);
+            if (Type.GetType("Mono.Runtime") == null && _options.UseDualStackSocket)
+                _listener = TcpListener.Create(endpoint.Port);
+            else
+                _listener = new TcpListener(endpoint);
             if(_options.UseNagleAlgorithm.HasValue)
                 _listener.Server.NoDelay = !_options.UseNagleAlgorithm.Value;
 

--- a/vtortola.WebSockets/WebSocketListenerOptions.cs
+++ b/vtortola.WebSockets/WebSocketListenerOptions.cs
@@ -23,6 +23,7 @@ namespace vtortola.WebSockets
         public OnHttpNegotiationDelegate OnHttpNegotiation { get; set; }
         public Boolean? UseNagleAlgorithm { get; set; }
         public PingModes PingMode { get; set; }
+        public Boolean UseDualStackSocket { get; set; }
 
         static readonly String[] _noSubProtocols = new String[0];
         public WebSocketListenerOptions()
@@ -38,6 +39,7 @@ namespace vtortola.WebSockets
             OnHttpNegotiation = null;
             UseNagleAlgorithm = true;
             PingMode = PingModes.LatencyControl;
+            UseDualStackSocket = false;
         }
         public void CheckCoherence()
         {
@@ -80,7 +82,8 @@ namespace vtortola.WebSockets
                 BufferManager = this.BufferManager,
                 OnHttpNegotiation = this.OnHttpNegotiation,
                 UseNagleAlgorithm = this.UseNagleAlgorithm,
-                PingMode = this.PingMode
+                PingMode = this.PingMode,
+                UseDualStackSocket = this.UseDualStackSocket
             };
         }
     }


### PR DESCRIPTION
I've needed a possibility to listen to both ip stacks. Currently this will works only with Microsoft dotNet 4.5 and above. Because of a lack of implementation Mono is not supported yet.

I've tested it with Microsoft OS 8.1 and 10 with the latest dotNet Framework installed.