### PR TITLE
use asyncwrite in ping operations

### DIFF
--- a/vtortola.WebSockets.Rfc6455/Ping/BandwidthSavingPing.cs
+++ b/vtortola.WebSockets.Rfc6455/Ping/BandwidthSavingPing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace vtortola.WebSockets.Rfc6455
@@ -40,7 +41,7 @@ namespace vtortola.WebSockets.Rfc6455
                     }
                     else if (_lastActivity.Add(_pingInterval) < now)
                     {
-                        _connection.WriteInternal(_pingBuffer, 0, true, false, WebSocketFrameOption.Ping, WebSocketExtensionFlags.None);
+                        await _connection.WriteInternalAsync(_pingBuffer, 0, true, false, WebSocketFrameOption.Ping, WebSocketExtensionFlags.None, CancellationToken.None).ConfigureAwait(false);
                     }
                 }
                 catch(Exception ex)

--- a/vtortola.WebSockets.Rfc6455/Ping/LatencyControlPing.cs
+++ b/vtortola.WebSockets.Rfc6455/Ping/LatencyControlPing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace vtortola.WebSockets.Rfc6455
@@ -40,7 +41,7 @@ namespace vtortola.WebSockets.Rfc6455
                     else
                     {
                         ((UInt64)now.Ticks).ToBytes(_pingBuffer.Array, _pingBuffer.Offset);
-                        _connection.WriteInternal(_pingBuffer, 8, true, false, WebSocketFrameOption.Ping, WebSocketExtensionFlags.None);
+                        await _connection.WriteInternalAsync(_pingBuffer, 8, true, false, WebSocketFrameOption.Ping, WebSocketExtensionFlags.None, CancellationToken.None).ConfigureAwait(false);
                     }
                 }
                 catch(Exception ex)

--- a/vtortola.WebSockets.Rfc6455/WebSocketConnectionRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketConnectionRfc6455.cs
@@ -332,7 +332,7 @@ namespace vtortola.WebSockets.Rfc6455
                     SafeEnd.ReleaseSemaphore(_writeSemaphore);
             }
         }
-        private async Task WriteInternalAsync(ArraySegment<Byte> buffer, Int32 count, Boolean isCompleted, Boolean headerSent, WebSocketFrameOption option, WebSocketExtensionFlags extensionFlags, CancellationToken cancellation)
+        internal async Task WriteInternalAsync(ArraySegment<Byte> buffer, Int32 count, Boolean isCompleted, Boolean headerSent, WebSocketFrameOption option, WebSocketExtensionFlags extensionFlags, CancellationToken cancellation)
         {
             CancellationTokenRegistration reg = cancellation.Register(this.Close, false);
             try


### PR DESCRIPTION
Use asynchronous write in ping strategy to avoid situation when dead client connections block threads causing thread starvation.
