### PR TITLE
HTTP Header Case Insensitive Compare

### DIFF
--- a/tests/WebSocketListener.UnitTests/With_WebSocketHandshaker.cs
+++ b/tests/WebSocketListener.UnitTests/With_WebSocketHandshaker.cs
@@ -133,7 +133,57 @@ namespace WebSocketListenerTests.UnitTests
                     Assert.AreEqual(sb.ToString(), s);
                 }
             }
-            
+        }
+
+        [TestMethod]
+        public void WebSocketHandshaker_CanDoSimpleHandshakeVerifyCaseInsensitive()
+        {
+            WebSocketHandshaker handshaker = new WebSocketHandshaker(_factories, new WebSocketListenerOptions());
+
+            using (var ms = new MemoryStream())
+            {
+                using (var sw = new StreamWriter(ms, Encoding.ASCII, 1024, true))
+                {
+                    sw.WriteLine(@"GET /chat HTTP/1.1");
+                    sw.WriteLine(@"Host: server.example.com");
+                    sw.WriteLine(@"Upgrade: websocket");
+                    sw.WriteLine(@"Connection: Upgrade");
+                    sw.WriteLine(@"Cookie: key=W9g/8FLW8RAFqSCWBvB9Ag==#5962c0ace89f4f780aa2a53febf2aae5;");
+                    sw.WriteLine(@"Sec-Websocket-Key: x3JJHMbDL1EzLkh9GBhXDw==");
+                    sw.WriteLine(@"Sec-Websocket-Version: 13");
+                    sw.WriteLine(@"Origin: http://example.com");
+                }
+
+                var position = ms.Position;
+                ms.Seek(0, SeekOrigin.Begin);
+
+                var result = handshaker.HandshakeAsync(ms).Result;
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.IsWebSocketRequest);
+                Assert.IsTrue(result.IsVersionSupported);
+                Assert.AreEqual(new Uri("http://example.com"), result.Request.Headers.Origin);
+                Assert.AreEqual("server.example.com", result.Request.Headers[HttpRequestHeader.Host]);
+                Assert.AreEqual(@"/chat", result.Request.RequestUri.ToString());
+                Assert.AreEqual(1, result.Request.Cookies.Count);
+                var cookie = result.Request.Cookies[0];
+                Assert.AreEqual("key", cookie.Name);
+                Assert.AreEqual(@"W9g/8FLW8RAFqSCWBvB9Ag==#5962c0ace89f4f780aa2a53febf2aae5", cookie.Value);
+
+                ms.Seek(position, SeekOrigin.Begin);
+
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine(@"HTTP/1.1 101 Switching Protocols");
+                sb.AppendLine(@"Upgrade: websocket");
+                sb.AppendLine(@"Connection: Upgrade");
+                sb.AppendLine(@"Sec-WebSocket-Accept: HSmrc0sMlYUkAGmm5OPpG2HaGWk=");
+                sb.AppendLine();
+
+                using (var sr = new StreamReader(ms))
+                {
+                    var s = sr.ReadToEnd();
+                    Assert.AreEqual(sb.ToString(), s);
+                }
+            }
         }
 
         [TestMethod]

--- a/vtortola.WebSockets/Http/HttpHeadersCollection.cs
+++ b/vtortola.WebSockets/Http/HttpHeadersCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net;
+using vtortola.WebSockets.Http;
 
 namespace vtortola.WebSockets
 {
@@ -45,17 +46,17 @@ namespace vtortola.WebSockets
             Uri uri;
             switch (name)
             {
-                case "Origin":
+                case WebSocketHeaders.Origin:
                     if (String.Equals(value, "null", StringComparison.OrdinalIgnoreCase))
                         uri = null;
                     else if (!Uri.TryCreate(value, UriKind.Absolute, out uri))
                         throw new WebSocketException("Cannot parse '" + value + "' as Origin header Uri");
                     Origin = uri;
                     break;
-                case "Host":
+                case WebSocketHeaders.Host:
                     Host = value;
                     break;
-                case "Sec-WebSocket-Version":
+                case WebSocketHeaders.Version:
                     WebSocketVersion = Int16.Parse(value);
                     break;
             }

--- a/vtortola.WebSockets/Http/WebSocketHandshake.cs
+++ b/vtortola.WebSockets/Http/WebSocketHandshake.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Text;
+using vtortola.WebSockets.Http;
 
 namespace vtortola.WebSockets
 {
@@ -38,7 +39,7 @@ namespace vtortola.WebSockets
         public String GenerateHandshake()
         {
             SHA1 sha1 = SHA1.Create();
-            return Convert.ToBase64String(sha1.ComputeHash(Encoding.UTF8.GetBytes(Request.Headers["Sec-WebSocket-Key"] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")));
+            return Convert.ToBase64String(sha1.ComputeHash(Encoding.UTF8.GetBytes(Request.Headers[WebSocketHeaders.Key] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")));
         }
     }
 }

--- a/vtortola.WebSockets/Http/WebSocketHeaders.cs
+++ b/vtortola.WebSockets/Http/WebSocketHeaders.cs
@@ -1,0 +1,26 @@
+﻿
+namespace vtortola.WebSockets.Http
+{
+    public static class WebSocketHeaders
+    {
+        public const string Host = "host";
+
+        public const string Upgrade = "upgrade";
+
+        public const string Connection = "connection";
+
+        public const string Key = "sec-websocket-key";
+
+        public const string Version = "sec-websocket-version";
+
+        public const string UpgradeExpectedValue = "websocket";
+
+        public const string Protocol = "sec-websocket-protocol";
+
+        public const string Extensions = "sec-websocket-extensions";
+
+        public const string Cookie = "cookie";
+
+        public const string Origin = "origin";
+    }
+}

--- a/vtortola.WebSockets/packages.config
+++ b/vtortola.WebSockets/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
+  <package id="Moq" version="4.5.16" targetFramework="net45" />
 </packages>

--- a/vtortola.WebSockets/vtortola.WebSockets.csproj
+++ b/vtortola.WebSockets/vtortola.WebSockets.csproj
@@ -42,6 +42,14 @@
     <AssemblyOriginatorKeyFile>WebSocketListener.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.16.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.16\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceModel" />
@@ -69,6 +77,7 @@
     <Compile Include="Header\WebSocketMessageType.cs" />
     <Compile Include="Http\HttpHeadersCollection.cs" />
     <Compile Include="Http\WebSocketException.cs" />
+    <Compile Include="Http\WebSocketHeaders.cs" />
     <Compile Include="Http\WebSocketHttpRequest.cs" />
     <Compile Include="Http\WebSocketHttpResponse.cs" />
     <Compile Include="Http\WebSocketNegotiationResult.cs" />


### PR DESCRIPTION
Hello,

We are using this library in our application and recently discovered that the HTTP headers like "WebSocket-Version" was coming across "Websocket-Version", notice the lowercase "S".  This was causing the handshake not to complete in the websocket library.

The changes are to make the HTTP header validation case insensitive.

Thank You.