### PR TITLE
Fixed CS4014  - Not awaiting a Task

### DIFF
--- a/vtortola.WebSockets/Http/HttpNegotiationQueue.cs
+++ b/vtortola.WebSockets/Http/HttpNegotiationQueue.cs
@@ -58,7 +58,7 @@ namespace vtortola.WebSockets.Http
                 {
                     await _semaphore.WaitAsync(_cancel.Token).ConfigureAwait(false);
                     var socket = await _sockets.ReceiveAsync(_cancel.Token).ConfigureAwait(false);
-                    Task.Run(() => NegotiateWebSocket(socket));
+                    await Task.Run(() => NegotiateWebSocket(socket));
                 }
                 catch (TaskCanceledException)
                 {


### PR DESCRIPTION
Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.