### PR TITLE
Enable .NET 4.5 build

### DIFF
--- a/vtortola.WebSockets/Http/CookieParser.cs
+++ b/vtortola.WebSockets/Http/CookieParser.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
-using System.Web;
 
 namespace vtortola.WebSockets
 {
@@ -42,7 +40,7 @@ namespace vtortola.WebSockets
         }
         private Cookie CreateCookie(string key, string value)
         {
-            return new Cookie(key.Trim(), HttpUtility.UrlDecode(value.Trim()));
+            return new Cookie(key.Trim(), WebUtility.UrlDecode(value.Trim()));
         }
     }
 }

--- a/vtortola.WebSockets/vtortola.WebSockets.csproj
+++ b/vtortola.WebSockets/vtortola.WebSockets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Version>3.0.0-beta</Version>
     <Description>Lightweight and highly scalable asynchronous WebSocket listener, compilant with the official RFC6455 specification. It supports async/await operations, SSL/TLS (wss://), message compression, customizable HTTP negotiation, built-in keep-alive, latency control, partial frames and have several extensibility points.</Description>
     <Authors>vtortola</Authors>


### PR DESCRIPTION
The code is (mostly) compatible with .NET 4.5 already. With a simple change to the project file, the resulting NuGet package can also be used by .NET 4.5 projects.