### PR TITLE
Fixing reading frame header async when the initial read does not read a full frame.

### DIFF
--- a/vtortola.WebSockets/Header/WebSocketFrameHeader.cs
+++ b/vtortola.WebSockets/Header/WebSocketFrameHeader.cs
@@ -106,14 +106,14 @@ namespace vtortola.WebSockets.Rfc6455
                 if (frameStart.Length < headerLength)
                     return false;
                 
-                contentLength = frameStart.ToUInt16(2, BitConverter.IsLittleEndian);
+                contentLength = frameStart.ToUInt16(offset+2, BitConverter.IsLittleEndian);
             }
             else if (contentLength == 127)
             {
                 if (frameStart.Length < headerLength)
                     return false;
 
-                var length = frameStart.ToUInt64(2, BitConverter.IsLittleEndian);
+                var length = frameStart.ToUInt64(offset+2, BitConverter.IsLittleEndian);
                 if (length > long.MaxValue)
                 {
                     throw new WebSocketException("The maximum supported frame length is 9223372036854775807, current frame is " + length.ToString());

--- a/vtortola.WebSockets/Rfc6455/WebSocketConnectionRfc6455.cs
+++ b/vtortola.WebSockets/Rfc6455/WebSocketConnectionRfc6455.cs
@@ -248,19 +248,23 @@ namespace vtortola.WebSockets.Rfc6455
 
         private async Task ParseHeaderAsync(int readed)
         {
-            if (await TryReadHeaderUntilAsync(readed, 6).ConfigureAwait(false) == -1)
+            var bytesRead = await TryReadHeaderUntilAsync(readed, 6).ConfigureAwait(false);
+            if (bytesRead == -1)
             {
                 Close(WebSocketCloseReasons.ProtocolError);
                 return;
             }
+            readed += bytesRead;
 
             var headerlength = WebSocketFrameHeader.GetHeaderLength(_headerBuffer.Array, _headerBuffer.Offset);
 
-            if (await TryReadHeaderUntilAsync(readed, headerlength).ConfigureAwait(false) == -1)
+            bytesRead = await TryReadHeaderUntilAsync(readed, headerlength).ConfigureAwait(false);
+            if (bytesRead == -1)
             {
                 Close(WebSocketCloseReasons.ProtocolError);
                 return;
             }
+            readed += bytesRead;
 
             await ProcessHeaderFrameAsync(headerlength).ConfigureAwait(false);
         }


### PR DESCRIPTION
webSocket.ReadStringAsync would improperly the frame header when it did not read the full header.